### PR TITLE
fixes sling code for short walls and adds sample

### DIFF
--- a/pegmixer.scad
+++ b/pegmixer.scad
@@ -163,9 +163,10 @@ module box(
 
     frontwall_z_push = is_undef($front_wall_height) ? 0 : (dims.z-$front_wall_height)/2 + half_wall_thickness;
     
-    module translated_side_wall() 
-        left((dims.x + $wall_thickness)/2) 
-                side_wall();
+    module translated_side_wall()
+        if ($side_wall_height > 0) 
+            left((dims.x + $wall_thickness)/2) 
+                    side_wall();
     module translated_bottom() 
         down((dims.z + top_add_h) / 2) bottom_wall();
 

--- a/samples/compact-multimeter.scad
+++ b/samples/compact-multimeter.scad
@@ -1,0 +1,14 @@
+include <../pegmixer.scad>
+
+h= 54;
+
+pegmixer() 
+    slingify_box(
+        side_height= 0,
+        front_height= h
+    )
+        box(
+            use_brace= false,
+            use_thinning= false,
+            [62, 23,h]
+        );

--- a/samples/compact-multimeter.scad
+++ b/samples/compact-multimeter.scad
@@ -1,6 +1,9 @@
 include <../pegmixer.scad>
 
-h= 54;
+h= 54; /* height of the front and back wall */
+w= 62; /* width of the inner portion (does not include wall width on left and right) */
+d= 23; /* depth of the inside of the sling */
+
 
 pegmixer() 
     slingify_box(
@@ -10,5 +13,5 @@ pegmixer()
         box(
             use_brace= false,
             use_thinning= false,
-            [62, 23,h]
+            [w, d, h]
         );


### PR DESCRIPTION
- Fixes a bug in pegmixer where the a slingified sidewall that has a 0 z would fail to render. 
- Adds a sample to that illustrates how to create a sling with no side walls.