### PR TITLE
adds epsilon nudge for mesh fix

### DIFF
--- a/pegmixer.scad
+++ b/pegmixer.scad
@@ -296,11 +296,12 @@ module default_peg_set()
 module _place_pegs() 
     tag("hooks")
         _hook_repeat(floor($x/$spacing))
-            if ($children == 0) {
-                default_peg_set();
-            } else {
-                children();
-            }
+            fwd($epsilon)
+                if ($children == 0) {
+                    default_peg_set();
+                } else {
+                    children();
+                }
 
 module alignment_peg()
     path_extrude2d(


### PR DESCRIPTION
I noticed that Cura 5.x occasionally decides there is a zero-width wall between an upper peg and the back wall a flat piece of geometry - e.g. it treats the main geometry and the peg is two separate meshes 🤦‍♂️. This causes a weak joint between that one peg and the hanging object.

This fix nudges the pegs an epsilon into the back of the object; it's not even resolvable by a printer, but it forces Cura to treat it as single mesh instead of two.